### PR TITLE
Alternate API with a record of functions.

### DIFF
--- a/src/Accordion.elm
+++ b/src/Accordion.elm
@@ -1,4 +1,4 @@
-module Accordion (Accordion, view) where
+module Accordion (Accordion, view, originalView) where
 
 
 import Html exposing (Html, Attribute, div)
@@ -144,3 +144,23 @@ view accordion entries =
 role : String -> Attribute
 role =
     attribute "role"
+
+
+{-| An implementation of the original API, for easy transition to the new API.
+-}
+originalView :
+    (entry -> Html) ->
+    (entry -> Html) ->
+    (Bool -> entry -> Message) ->
+    List (entry, Bool) -> Html
+originalView viewHeader viewPanel setExpanded list =
+    let
+        accordion =
+            { viewHeader = viewHeader << fst
+            , viewPanel = viewPanel << fst
+            , setExpanded = \expanded entry -> setExpanded expanded (fst entry) 
+            , getExpanded = snd
+            }
+
+    in
+        view accordion list

--- a/src/Accordion.elm
+++ b/src/Accordion.elm
@@ -1,4 +1,4 @@
-module Accordion (view) where
+module Accordion (Accordion, view) where
 
 
 import Html exposing (Html, Attribute, div)
@@ -8,28 +8,40 @@ import Signal exposing (Message)
 import Json.Decode
 
 
+{-| Functions which indicate how to display your `entry` type as an
+accordion section.
+
+`viewHeader` and `viewPanel` will be called with each `entry` to render
+the title and body of a particular accordion section, respectively.
+These functions will be passed a single `entry` and should render it
+appropriately. In the simplest case, just use `Html.text` to render text only,
+but you might also want to render (for example) an icon in the header or
+structured paragraphs in the body.
+
+`setExpanded` will be called to translate header clicks into `Message` values, so you can
+update your model as appropriate. It receives a `Bool` indicating whether
+the given `entry` is to become expanded, followed by the `entry` itself.
+
+`getExpanded` will be called with an `entry` to determine whether it ought
+to be displayed in expanded form.
+-}
+type alias Accordion entry =
+    { viewHeader : entry -> Html
+    , viewPanel : entry -> Html
+    , setExpanded : Bool -> entry -> Message
+    , getExpanded : entry -> Bool
+    }
+
+
 {-| Render an Accordion view.
 
-An accordion is a list of sections, each with a header and body, and each
+An accordion is rendered as a list of sections, each with a header and body, and each
 with a notion of whether it is expanded or collapsed. When the user clicks
 a given header, the accordion sends a `Message` requesting that the section
 in question swap its expandedness/collapsedness.
 
-Start with a list of `entry` values, each paired with a `Bool` indicating
-whether that entry should be expanded.
-
-The first two arguments to `view` are functions which render the title and
-the body of a particular accordion section, respectively. These functions will
-be passed a single `entry` and should render it appropriately. In the simplest
-case, just use `Html.text` to render text only, but you might also want to
-render (for example) an icon in the header or structured paragraphs in the body.
-
-The third argument translates header clicks into `Message` values, so you can
-update your model as appropriate. It receives a `Bool` indicating whether
-the given `entry` is to become expanded, followed by the `entry` itself.
-
-The final argument is the list of entries, each wrapped in a Tuple with a `Bool`
-indicating whether it should be expanded.
+Provide a list of `entry` values, and an `Accordion` record that indicates
+how we can display an `entry` as an accordion section.
 
 Example Usage:
 
@@ -37,29 +49,36 @@ Example Usage:
         = NoOp
         | SetExpanded Int Bool
 
+    actions =
+        Signal.mailbox NoOp
 
+    -- You could keep track of `expanded` in a separate data structure, if that
+    -- were desirable, by supplying an appropriate `setExpanded` and
+    -- `getExpanded` for the `Accordion`
     sampleEntry =
         { id = 1
         , title = "Walden"
         , synopsis = "A student is bitten by a radioactive spider..."
+        , expanded = True
         }
 
+    accordion =
+        { viewHeader = .title >> Html.text
+        , viewPanel = .synopsis >> Html.text
+        , setExpanded = \expanded {id} -> Signal.message actions.address (SetExpanded id expanded)
+        , getExpanded = .expanded
+        }
 
-    Accordion.view
-        (.title >> Html.text)
-        (.synopsis >> Html.text)
-        (\expanded {id} -> Signal.message actions (SetExpanded id expanded))
-        [ ( sampleEntry, True ) ]
+    Accordion.view accordion [ sampleEntry ]
 -}
-view :
-    (entry -> Html) ->
-    (entry -> Html) ->
-    (Bool -> entry -> Message) ->
-    List (entry, Bool) -> Html
-view viewHeader viewPanel toggleExpanded entries =
+view : Accordion entry -> List entry -> Html
+view accordion entries =
     let
-        viewEntry (entry, expanded) =
+        viewEntry entry =
             let
+                expanded =
+                    accordion.getExpanded entry
+
                 entryClass =
                     classList
                         [ "accordion-entry" => True
@@ -73,14 +92,14 @@ view viewHeader viewPanel toggleExpanded entries =
                         , on
                             "click"
                             (Json.Decode.succeed ())
-                            (\_ -> toggleExpanded (not expanded) entry)
+                            (\_ -> accordion.setExpanded (not expanded) entry)
                         ]
-                        [ viewHeader entry ]
+                        [ accordion.viewHeader entry ]
 
                 entryPanel =
                     div
                         [ class "accordion-entry-panel", role "tabpanel" ]
-                        [ viewPanel entry ]
+                        [ accordion.viewPanel entry ]
             in
                 div
                     [ entryClass, role "tab" ]

--- a/src/Accordion.elm
+++ b/src/Accordion.elm
@@ -49,12 +49,17 @@ Example Usage:
         = NoOp
         | SetExpanded Int Bool
 
-    actions =
-        Signal.mailbox NoOp
-
     -- You could keep track of `expanded` in a separate data structure, if that
     -- were desirable, by supplying an appropriate `setExpanded` and
-    -- `getExpanded` for the `Accordion`
+    -- `getExpanded` for the `Accordion`, and an appropriate `update` method
+    type alias Entry =
+        { id : Int
+        , title : String
+        , synopsis : String
+        , expanded : Bool
+        }
+
+    sampleEntry : Entry
     sampleEntry =
         { id = 1
         , title = "Walden"
@@ -62,14 +67,30 @@ Example Usage:
         , expanded = True
         }
 
-    accordion =
+    update : Action -> List Entry -> List Entry
+    update action model =
+        case action of
+            NoOp ->
+                model
+
+            SetExpanded id expanded ->
+                List.map (\entry ->
+                    if entry.id == id
+                        then { entry | expanded <- expanded }
+                        else entry
+                ) model
+
+    accordion : Signal.Address Action -> Accordion Entry
+    accordion address =
         { viewHeader = .title >> Html.text
         , viewPanel = .synopsis >> Html.text
-        , setExpanded = \expanded {id} -> Signal.message actions.address (SetExpanded id expanded)
+        , setExpanded = \expanded {id} -> Signal.message address (SetExpanded id expanded)
         , getExpanded = .expanded
         }
 
-    Accordion.view accordion [ sampleEntry ]
+    view : Signal.Address Action -> List Entry -> Html
+    view address model =
+        Accordion.view (accordion address) model
 -}
 view : Accordion entry -> List entry -> Html
 view accordion entries =


### PR DESCRIPTION
You had asked on the Google group for suggestions for alternate APIs, so I thought I'd try it as a PR -- obviously this is just a suggestion.

* Instead of requiring a `List (entry, Bool)`, require a `List entry` and an `entry -> Bool`. That way, we are less prescriptive re: how the client structures their data ... they just have to tell us how to find the expanded/collapsed state.

* Instead of asking for the various functions as separate parameters, ask for a record of those functions. The naming of the functions in the record makes things easier to follow for clients, and may promote re-usability in some scenarios.